### PR TITLE
Fix/kafka receiver bug

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,7 +48,7 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
-		OutputFilePath:             "/tmp/helloworld.txt",
+		OutputFilePath:             "/tmp/searchdatafinder.txt",
 		KafkaConfig: KafkaConfig{
 			Brokers:               []string{"localhost:9092"},
 			Version:               "1.0.2",

--- a/features/steps/example_component.go
+++ b/features/steps/example_component.go
@@ -29,6 +29,7 @@ func NewComponent() *Component {
 
 	consumer := kafkatest.NewMessageConsumer(false)
 	consumer.CheckerFunc = funcCheck
+	consumer.StartFunc = func() error { return nil }
 	c.KafkaConsumer = consumer
 
 	cfg, err := config.Get()

--- a/service/service.go
+++ b/service/service.go
@@ -45,7 +45,12 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 	}
 
 	// Event Handler for Kafka Consumer
-	event.Consume(ctx, consumer, &event.ReindexRequestedHandler{}, cfg)
+	handler := &event.ReindexRequestedHandler{}
+	event.Consume(ctx, consumer, handler, cfg)
+	if err := consumer.Start(); err != nil {
+		log.Fatal(ctx, "error starting the consumer", err)
+		return nil, err
+	}
 
 	// Get HealthCheck
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)

--- a/service/service.go
+++ b/service/service.go
@@ -47,9 +47,9 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 	// Event Handler for Kafka Consumer
 	handler := &event.ReindexRequestedHandler{}
 	event.Consume(ctx, consumer, handler, cfg)
-	if err := consumer.Start(); err != nil {
-		log.Fatal(ctx, "error starting the consumer", err)
-		return nil, err
+	if consumerStartErr := consumer.Start(); consumerStartErr != nil {
+		log.Fatal(ctx, "error starting the consumer", consumerStartErr)
+		return nil, consumerStartErr
 	}
 
 	// Get HealthCheck

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -46,6 +46,7 @@ func TestRun(t *testing.T) {
 		consumerMock := &kafkatest.IConsumerGroupMock{
 			CheckerFunc:  func(ctx context.Context, state *healthcheck.CheckState) error { return nil },
 			ChannelsFunc: func() *kafka.ConsumerGroupChannels { return &kafka.ConsumerGroupChannels{} },
+			StartFunc:    func() error { return nil },
 		}
 
 		hcMock := &serviceMock.HealthCheckerMock{
@@ -173,6 +174,7 @@ func TestClose(t *testing.T) {
 			CloseFunc:    func(ctx context.Context) error { return nil },
 			CheckerFunc:  func(ctx context.Context, state *healthcheck.CheckState) error { return nil },
 			ChannelsFunc: func() *kafka.ConsumerGroupChannels { return &kafka.ConsumerGroupChannels{} },
+			StartFunc:    func() error { return nil },
 		}
 
 		// healthcheck Stop does not depend on any other service being closed/stopped


### PR DESCRIPTION
### What

This PR Fixes the kafka receiver handler by starting the consumer to receive kafka messages published to the topic. Earlier the consumer was not started and thus was not receiving the messaged published to the relevant topic. 

### How to review

This is tested locally with test producer sending message to the kafka topic and this service receiving the message from the reindex-requested topic. 

### Who can review

Anyone except me. 
