### PR TITLE
Set the zebedee client timeout to default to 30 seconds and make it c…

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,7 +16,8 @@ type Config struct {
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	KafkaConfig                KafkaConfig
-	ZebedeeURL                 string `envconfig:"ZEBEDEE_URL"`
+	ZebedeeClientTimeout       time.Duration `envconfig:"ZEBEDEE_CLIENT_TIMEOUT"`
+	ZebedeeURL                 string        `envconfig:"ZEBEDEE_URL"`
 }
 
 // KafkaConfig contains the config required to connect to Kafka
@@ -64,7 +65,8 @@ func Get() (*Config, error) {
 			SecSkipVerify:         false,
 			Version:               "1.0.2",
 		},
-		ZebedeeURL: "http://localhost:8082",
+		ZebedeeClientTimeout: 30 * time.Second,
+		ZebedeeURL:           "http://localhost:8082",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/service/service.go
+++ b/service/service.go
@@ -54,6 +54,7 @@ func Run(ctx context.Context, serviceList *ExternalServiceList, buildTime, gitCo
 	}
 
 	httpClient := dpHTTP.NewClient()
+	httpClient.SetTimeout(cfg.ZebedeeClientTimeout) // Published Index takes about 10s to return so add a bit more
 	zebedeeClient := newZebedeeClient(httpClient, cfg)
 
 	// Event Handler for Kafka Consumer


### PR DESCRIPTION
# What has changed
<!--- Why is this change required? What problem does it solve? -->
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
The service is currently failing in develop with the following error message:

"event":"failed to handle event","severity":1,"errors":[{"message":"context deadline exceeded (Client.Timeout or context cancellation while reading body)",

This is because the response from Zebedee (that is called by the event handler) is slower than the timeout, of the request, which is the default timeout set by the dp-net library.

This code change sets the timeout to be 30 seconds, which should be long enough for the request to be dealt with.

# How to review
<!--- Describe in detail how you tested your changes. -->
Check that the code looks correct and that the following tests pass:

make test

go test -component

make lint

# Who can review
<!--- Give names if specific reviewers required, otherwise say "Anyone but me". -->
Anyone but me
