### PR TITLE
Call zebedee directly rather than going via api router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	ServiceAuthToken                 string        `envconfig:"SERVICE_AUTH_TOKEN"   json:"-"`
 	ZebedeeClientTimeout             time.Duration `envconfig:"ZEBEDEE_CLIENT_TIMEOUT"`
 	EnablePublishContentUpdatedTopic bool          `envconfig:"ENABLE_PUBLISH_CONTENT_UPDATED_TOPIC"`
+	ZebedeeURL                       string        `envconfig:"ZEBEDEE_URL"`
 }
 
 // KafkaConfig contains the config required to connect to Kafka
@@ -69,6 +70,7 @@ func Get() (*Config, error) {
 		},
 		ServiceAuthToken:     "",
 		ZebedeeClientTimeout: 30 * time.Second,
+		ZebedeeURL:           "http://localhost:8082",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/features/steps/component.go
+++ b/features/steps/component.go
@@ -88,7 +88,7 @@ func NewSearchDataFinderComponent() (*Component, error) {
 		DoGetHealthCheckFunc:  getHealthCheckOK,
 		DoGetHealthClientFunc: c.getHealthClientOK,
 		DoGetHTTPServerFunc:   c.getHTTPServer,
-		DoGetZebedeeClientFunc: func(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient {
+		DoGetZebedeeClientFunc: func(cfg *config.Config) clients.ZebedeeClient {
 			return c.zebedeeClient
 		},
 		DoGetDatasetAPIClientFunc: func(hcCli *health.Client) clients.DatasetAPIClient {

--- a/service/initialise.go
+++ b/service/initialise.go
@@ -81,8 +81,8 @@ func (e *Init) DoGetHTTPServer(bindAddr string, router http.Handler) HTTPServer 
 }
 
 // GetZebedee return Zebedee client
-func (e *ExternalServiceList) GetZebedee(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient {
-	zebedeeClient := e.Init.DoGetZebedeeClient(cfg, hcCli)
+func (e *ExternalServiceList) GetZebedee(cfg *config.Config) clients.ZebedeeClient {
+	zebedeeClient := e.Init.DoGetZebedeeClient(cfg)
 	e.ZebedeeCli = true
 	return zebedeeClient
 }
@@ -95,14 +95,14 @@ func (e *ExternalServiceList) GetDatasetAPI(hcCli *health.Client) clients.Datase
 }
 
 // DoGetZebedeeClient gets and initialises the Zebedee Client
-func (e *Init) DoGetZebedeeClient(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient {
+func (e *Init) DoGetZebedeeClient(cfg *config.Config) clients.ZebedeeClient {
 	httpClient := dpHTTP.NewClient()
 
 	// as of 06/10/2022 published index takes about 10s to return so add a bit more, this could increase or decrease in the future
 	httpClient.SetTimeout(cfg.ZebedeeClientTimeout)
 
-	// communicating to zebedee via api-router (hcCli.URL) with configurable client (httpClient)
-	zebedeeClient := zebedee.NewClientWithClienter(hcCli.URL, httpClient)
+	// communicating to zebedee directly with configurable client (httpClient)
+	zebedeeClient := zebedee.NewClientWithClienter(cfg.ZebedeeURL, httpClient)
 
 	return zebedeeClient
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -22,7 +22,7 @@ type Initialiser interface {
 	DoGetHealthClient(name, url string) *health.Client
 	DoGetKafkaConsumer(ctx context.Context, kafkaCfg *config.KafkaConfig) (kafka.IConsumerGroup, error)
 	DoGetKafkaProducer(ctx context.Context, cfg *config.Config) (kafka.IProducer, error)
-	DoGetZebedeeClient(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient
+	DoGetZebedeeClient(cfg *config.Config) clients.ZebedeeClient
 	DoGetDatasetAPIClient(hcCli *health.Client) clients.DatasetAPIClient
 }
 

--- a/service/mock/initialiser.go
+++ b/service/mock/initialiser.go
@@ -42,7 +42,7 @@ var _ service.Initialiser = &InitialiserMock{}
 //			DoGetKafkaProducerFunc: func(ctx context.Context, cfg *config.Config) (kafka.IProducer, error) {
 //				panic("mock out the DoGetKafkaProducer method")
 //			},
-//			DoGetZebedeeClientFunc: func(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient {
+//			DoGetZebedeeClientFunc: func(cfg *config.Config) clients.ZebedeeClient {
 //				panic("mock out the DoGetZebedeeClient method")
 //			},
 //		}
@@ -71,7 +71,7 @@ type InitialiserMock struct {
 	DoGetKafkaProducerFunc func(ctx context.Context, cfg *config.Config) (kafka.IProducer, error)
 
 	// DoGetZebedeeClientFunc mocks the DoGetZebedeeClient method.
-	DoGetZebedeeClientFunc func(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient
+	DoGetZebedeeClientFunc func(cfg *config.Config) clients.ZebedeeClient
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -123,8 +123,6 @@ type InitialiserMock struct {
 		DoGetZebedeeClient []struct {
 			// Cfg is the cfg argument value.
 			Cfg *config.Config
-			// HcCli is the hcCli argument value.
-			HcCli *health.Client
 		}
 	}
 	lockDoGetDatasetAPIClient sync.RWMutex
@@ -357,21 +355,19 @@ func (mock *InitialiserMock) DoGetKafkaProducerCalls() []struct {
 }
 
 // DoGetZebedeeClient calls DoGetZebedeeClientFunc.
-func (mock *InitialiserMock) DoGetZebedeeClient(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient {
+func (mock *InitialiserMock) DoGetZebedeeClient(cfg *config.Config) clients.ZebedeeClient {
 	if mock.DoGetZebedeeClientFunc == nil {
 		panic("InitialiserMock.DoGetZebedeeClientFunc: method is nil but Initialiser.DoGetZebedeeClient was just called")
 	}
 	callInfo := struct {
-		Cfg   *config.Config
-		HcCli *health.Client
+		Cfg *config.Config
 	}{
-		Cfg:   cfg,
-		HcCli: hcCli,
+		Cfg: cfg,
 	}
 	mock.lockDoGetZebedeeClient.Lock()
 	mock.calls.DoGetZebedeeClient = append(mock.calls.DoGetZebedeeClient, callInfo)
 	mock.lockDoGetZebedeeClient.Unlock()
-	return mock.DoGetZebedeeClientFunc(cfg, hcCli)
+	return mock.DoGetZebedeeClientFunc(cfg)
 }
 
 // DoGetZebedeeClientCalls gets all the calls that were made to DoGetZebedeeClient.
@@ -379,12 +375,10 @@ func (mock *InitialiserMock) DoGetZebedeeClient(cfg *config.Config, hcCli *healt
 //
 //	len(mockedInitialiser.DoGetZebedeeClientCalls())
 func (mock *InitialiserMock) DoGetZebedeeClientCalls() []struct {
-	Cfg   *config.Config
-	HcCli *health.Client
+	Cfg *config.Config
 } {
 	var calls []struct {
-		Cfg   *config.Config
-		HcCli *health.Client
+		Cfg *config.Config
 	}
 	mock.lockDoGetZebedeeClient.RLock()
 	calls = mock.calls.DoGetZebedeeClient

--- a/service/service.go
+++ b/service/service.go
@@ -37,7 +37,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	routerHealthClient := serviceList.GetHealthClient("api-router", cfg.APIRouterURL)
 
 	// Get the zebedee client
-	zebedeeClient := serviceList.GetZebedee(cfg, routerHealthClient)
+	zebedeeClient := serviceList.GetZebedee(cfg)
 
 	// Get dataset-api client
 	datasetAPIClient := serviceList.GetDatasetAPI(routerHealthClient)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -103,7 +103,7 @@ func TestRun(t *testing.T) {
 			return serverMock
 		}
 
-		funcDoGetZebedeeOk := func(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient {
+		funcDoGetZebedeeOk := func(cfg *config.Config) clients.ZebedeeClient {
 			return zebedeeMock
 		}
 
@@ -292,7 +292,7 @@ func TestClose(t *testing.T) {
 				DoGetKafkaProducerFunc: func(ctx context.Context, config *config.Config) (kafka.IProducer, error) {
 					return producerMock, nil
 				},
-				DoGetZebedeeClientFunc:    func(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient { return zebedeeMock },
+				DoGetZebedeeClientFunc:    func(cfg *config.Config) clients.ZebedeeClient { return zebedeeMock },
 				DoGetDatasetAPIClientFunc: funcDoGetDatasetAPIOk,
 			}
 
@@ -328,7 +328,7 @@ func TestClose(t *testing.T) {
 				DoGetKafkaProducerFunc: func(ctx context.Context, config *config.Config) (kafka.IProducer, error) {
 					return producerMock, nil
 				},
-				DoGetZebedeeClientFunc:    func(cfg *config.Config, hcCli *health.Client) clients.ZebedeeClient { return zebedeeMock },
+				DoGetZebedeeClientFunc:    func(cfg *config.Config) clients.ZebedeeClient { return zebedeeMock },
 				DoGetDatasetAPIClientFunc: funcDoGetDatasetAPIOk,
 			}
 


### PR DESCRIPTION
### What

This pr attempts to call zebedee directly rather than going via the api router . This is because of the restrictions involved to increase the zebedee timeout if the call is routed via the api router service. 

### How to review

Please check if the changes make sense. 

### Who can review

Anyone except me. 
