### PR TITLE
Update Go version in CI

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.3
+    tag: 1.21.3-bullseye
 
 inputs:
   - name: dp-search-data-finder

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.3
+    tag: 1.21.3-bullseye
 
 inputs:
   - name: dp-search-data-finder

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.3
+    tag: 1.21.3-bullseye
 
 inputs:
   - name: dp-search-data-finder

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.21.3
+    tag: 1.21.3-bullseye
 
 inputs:
   - name: dp-search-data-finder


### PR DESCRIPTION
### What

Updated CI images to -bullseye to circumvent:
version `GLIBC_2.34' not found 

### How to review

Check tests pass
### Who can review

Not me. 